### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A Kanban integration for Trilium Notes
 ### From scratch
 
 - Create a note of type `Render Note`.
-  - Give this note the `renderNote` relation that points to the kanban integration note (`~renderNote=Kanban View`).
+  - Give this note the `template` relation that points to the kanban integration note (`~template=Kanban View`).
   - Give this note the `sorted` label with a value of `sortOrder` (`#sorted=sortOrder`).
 - Create a board by creating a sub-note of the main `Render Note` you created above.
 - Create an item by creating a sub-note of a board


### PR DESCRIPTION
The README explains how to create a kanban note manually by saying "Give this note the renderNote relation that points to the kanban integration note (~renderNote=Kanban View)."

That didn't work for me. A kanban note that was created by adding the kanban view _template_has a "template" relation, not a "renderNote". This seems to work for me. 